### PR TITLE
Statue Hostile Mob Health Reduction

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -14,8 +14,8 @@
 	response_disarm = "pushes"
 
 	speed = -1
-	maxHealth = 50000
-	health = 50000
+	maxHealth = 1000
+	health = 1000
 
 	harm_intent_damage = 70
 	melee_damage_lower = 68


### PR DESCRIPTION
Reduced the health of this mob from 50,000 to 1,000 to reduce the exploit of slimes being able to feed from it indefinitely.

Issue was reported to Lichling by Chaznoodles. Slimes are able to feed from this statue almost indefinitely (it's the same as feeding from a few hundred humans). Let's be honest, 50k HP is a little ridiculous anyway.
