### PR TITLE
Narrowed Targets of Virus Outbreak Event - Issue 92 Bugfix

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -26,6 +26,8 @@
 			continue
 		if(T.z != 1)
 			continue
+		if(!(H.dna))
+			continue
 		var/foundAlready = 0	// don't infect someone that already has the virus
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1


### PR DESCRIPTION
Added a check to reduce the targets of the virus outbreak event to only
those human mobs with a DNA datum (i.e. not the test subjects).

Resolves issue #92
