### PR TITLE
Issue 88 fix

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -265,6 +265,9 @@
 			var/obj/item/weapon/storage/book/B = new
 			B.name = src.name
 			B.title = src.title
+			B.icon_state = src.icon_state
+			B.icon = src.icon
+			B.desc = src.desc
 			if(user.l_hand == src || user.r_hand == src)
 				qdel(src)
 				user.put_in_hands(B)


### PR DESCRIPTION
Added icon_state, icon, and desc to the list of vars that transfer when the book is carved out. This resolves issue #88 
