### PR TITLE
put station_name instead of world.name on the supply manifest

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -65,7 +65,7 @@ var/religion_name = null
 		//get normal name
 		if(null,"",0)
 			//name = pick("", "Stanford", "Dorf", "Alium", "Prefix", "Clowning", "Aegis", "Ishimura", "Scaredy", "Death-World", "Mime", "Honk", "Rogue", "MacRagge", "Ultrameens", "Safety", "Paranoia", "Explosive", "Neckbear", "Donk", "Muppet", "North", "West", "East", "South", "Slant-ways", "Widdershins", "Rimward", "Expensive", "Procreatory", "Imperial", "Unidentified", "Immoral", "Carp", "Ork", "Pete", "Control", "Nettle", "Aspie", "Class", "Crab", "Fist","Corrogated","Skeleton","Race", "Fatguy", "Gentleman", "Capitalist", "Communist", "Bear", "Beard", "Derp", "Space", "Spess", "Star", "Moon", "System", "Mining", "Neckbeard", "Research", "Supply", "Military", "Orbital", "Battle", "Science", "Asteroid", "Home", "Production", "Transport", "Delivery", "Extraplanetary", "Orbital", "Correctional", "Robot", "Hats", "Pizza")
-			name = "Liberty "
+			name = "Liberty"
 			new_station_name += name + " "
 
 		//For special days like christmas, easter, new-years etc ~Carn

--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -356,7 +356,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 			var/obj/item/weapon/paper/manifest/slip = new /obj/item/weapon/paper/manifest(A)
 
-			var printed_station_name = world.name // World name is available in the title bar, station_name can be different based on config.
+			var printed_station_name = station_name // World name is available in the title bar, station_name can be different based on config.
 			if(prob(5))
 				printed_station_name = new_station_name()
 				slip.erroneous |= MANIFEST_ERROR_NAME // They got our station name wrong.  BASTARDS!


### PR DESCRIPTION
removed extra space in station name
put station_name instead of world.name on the supply manifest
