### PR TITLE
Disables Head/sec from getting traitor/ling.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -117,7 +117,7 @@ CHANGELING_SCALING_COEFF 7
 
 ## Uncomment to prohibit jobs that start with loyalty
 ## implants from being most antagonists.
-#PROTECT_ROLES_FROM_ANTAGONIST
+PROTECT_ROLES_FROM_ANTAGONIST
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS


### PR DESCRIPTION
http://www.llagaming.net/forums/threads/restrict-captain-and-sec-roles-from-antag-status.3139/
