### PR TITLE
Fix for https://github.com/Spoffy/LLA-Station-13/issues/85

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -122,6 +122,7 @@
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		pod.mix_air()
+		pod.eject_contents() //Prevents things getting stuck in pod
 
 // Tube station directions are simply 90 to either side of
 //  the exit.

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -149,6 +149,10 @@
 	loc.assume_air(from_int)
 	air_contents.merge(from_env)
 
+	
+/obj/structure/transit_tube_pod/proc/eject_contents()
+	for(var/atom/movable/AM in contents)
+		AM.loc = loc
 
 
 // When the player moves, check if the pos is currently stopped at a station.


### PR DESCRIPTION
Transit pods now eject things put in them when they reach a station. This is so that thinks that things like corpses and AIs don't get stuck in the pod forever.

Fix for https://github.com/Spoffy/LLA-Station-13/issues/85

The pod's ejects it's contents all on it's own tile. If this is a problem let me know.
