### PR TITLE
Removed space in pen.dm

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -55,7 +55,7 @@
 /*
  * Parapens
  */
- /obj/item/weapon/pen/paralysis
+/obj/item/weapon/pen/paralysis
 	origin_tech = "materials=2;syndicate=5"
 
 


### PR DESCRIPTION
Removed a space in pen.dm before the definition of the parapen which caused any pen used to attack to get set to the same origin tech settings as parapen, causing people to get erroneously labeled as traitor.
