### PR TITLE
Expanded Attack, Crit, and Death Logging

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -62,8 +62,10 @@ obj/item/proc/get_clamped_volume()
 	/////////////////////////
 	user.lastattacked = M
 	M.lastattacker = user
-
-	add_logs(user, M, "attacked", object=src.name, addition="(INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+	if (M.stat != DEAD)
+		add_logs(user, M, "attacked", object=src.name, addition=" (DAMAGE: [src.force]) (REMHP: [M.health - src.force]) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+	if (M.stat == DEAD)
+		add_logs(user, M, "attacked", object=src.name, addition=" (DAMAGE: [src.force]) (REMHP: DEAD) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 
 	//spawn(1800)            // this wont work right
 	//	M.lastattacker = null

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,6 +17,8 @@
 	if(stat == DEAD)	return
 	if(healths)		healths.icon_state = "health5"
 	stat = DEAD
+	attack_log += text("\[[time_stamp()]\] <font color ='red'>[key_name(src)] has died</font>")
+	log_attack("\[[time_stamp()]\] <font color ='red'>[key_name(src)] has died</font>")
 	dizziness = 0
 	jitteriness = 0
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -59,7 +59,11 @@
 			return 1
 
 		if("harm")
-			add_logs(M, src, "punched")
+			var/damage = rand(0, 9)
+			if (src.stat == DEAD)
+				add_logs(M, src, "punched", addition=" (DAMAGE: [damage]) (REMHP: DEAD)")
+			else
+				add_logs(M, src, "punched", addition=" (DAMAGE: [damage]) (REMHP: [src.health - damage])")
 
 			var/attack_verb = "punch"
 			if(lying)
@@ -71,7 +75,7 @@
 					if("plant")
 						attack_verb = "slash"
 
-			var/damage = rand(0, 9)
+
 			if(!damage)
 				switch(attack_verb)
 					if("slash")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -4,6 +4,9 @@
 		health = maxHealth
 		stat = CONSCIOUS
 		return
+	var/CritStatus = 0
+	if(health <= config.health_threshold_crit)
+		CritStatus = 1
 	var/total_burn	= 0
 	var/total_brute	= 0
 	for(var/obj/item/organ/limb/O in organs)	//hardcoded to streamline things a bit
@@ -13,6 +16,12 @@
 	//TODO: fix husking
 	if( ((maxHealth - total_burn) < config.health_threshold_dead) && stat == DEAD )
 		ChangeToHusk()
+	if((health > config.health_threshold_crit) && (CritStatus == 1))
+		src.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(src)] has left critical</font>")
+		log_attack("<font color='red'>[key_name(src)] has left critical</font>")
+	if((health <= config.health_threshold_crit) && (CritStatus == 0))
+		src.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(src)] has entered critical</font>")
+		log_attack("<font color='red'>[key_name(src)] has entered critical</font>")
 	return
 
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,7 +65,10 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		var/client/assailant = directory[ckey(I.fingerprintslast)]
 		if(assailant && assailant.mob && istype(assailant.mob,/mob))
 			var/mob/M = assailant.mob
-			add_logs(M, src, "hit", object="[I]")
+			if (src.stat == DEAD)
+				add_logs(M, src, "hit", object="[I]", addition = " (DAMAGE:[I.throwforce]) (REMHP: DEAD)")
+			else
+				add_logs(M, src, "hit", object="[I]", addition = " (DAMAGE:[I.throwforce]) (REMHP: [src.health])")
 
 //Mobs on Fire
 /mob/living/proc/IgniteMob()


### PR DESCRIPTION
Implemented Melee weapon damage and remaining HP logs
Implemented Thrown weapon damage and remaining HP logs
Implemented Punch damage and remaining HP logs
Implemented logging when critical is entered or left by a human
Implemented logging when a human dies
Made Remaining HP display as "DEAD" in attack logs when mob is dead to hide confusing unnecessary readings