### PR TITLE
CPR Log Fix and href Timestamp Improvement

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -36,7 +36,7 @@
 
 	//Logs all hrefs
 	if(config && config.log_hrefs && href_logfile)
-		href_logfile << "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>"
+		href_logfile << "<small>\[[time_stamp()]\] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>"
 
 	switch(href_list["_src_"])
 		if("holder")	hsrc = holder

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -24,7 +24,7 @@
 				return 0
 
 			if(cpr_time < world.time + 30)
-				add_logs(src, M, "CPRed")
+				add_logs(M, src, "CPRed")
 				visible_message("<span class='notice'>[M] is trying to perform CPR on [src]!</span>")
 				if(!do_mob(M, src))
 					return 0


### PR DESCRIPTION
-Changed href log timestamps to include seconds and use the standard proc.
-Fixed the CPR logs being backwards (the target was being logged as having CPR'd the person who was doing the CPR)

Tested and confirmed both worked as expected.