### PR TITLE
Fixed airlocks not closing correctly with hacked timing

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1029,7 +1029,7 @@ About the new airlock wires panel:
 		spawn(150)
 			autoclose()
 	else if(autoclose && !normalspeed)
-		spawn(5)
+		spawn(15)
 			autoclose()
 
 	return ..()
@@ -1044,8 +1044,12 @@ About the new airlock wires panel:
 	if(safe)
 		if(locate(/mob/living) in get_turf(src))
 		//	playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)	//THE BUZZING IT NEVER STOPS	-Pete
-			spawn (60)
-				close()
+			if(normalspeed)
+				spawn (60)
+					close()
+			else if(!normalspeed)
+				spawn (15)
+					close()
 			return
 
 	crush()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -52,6 +52,13 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 <div class='commit sansserif'>
+	<h2 class='date'>19 January 2015</h2>
+	<h3 class='author'>FlavoredCactus updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>Fixed airlock timing keeping doors open forever instead of closing them immediately after opening</li>
+	</ul>
+</div>
+<div class='commit sansserif'>
 	<h2 class='date'>17 January 2015</h2>
 	<h3 class='author'>FlavoredCactus updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
The issue was that the autoclose() proc was being called too quickly to
actually close the door

additionally i setup a if statement in the autoclose proc (Where it
checks if a human is there) that if the timing is hacked it would close
faster. tested and people walking through doors can still make it
through before the doors close quickly. tested while running too, works
fine.