### PR TITLE
Cult Balancing

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -534,6 +534,11 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				var/holy2unholy = M.reagents.get_reagent_amount("holywater")
 				M.reagents.del_reagent("holywater")
 				M.reagents.add_reagent("unholywater",holy2unholy)
+			if(M.reagents && M.reagents.has_reagent("ethanol/wine")) //allows cultists to be rescued from the clutches of ordained religion
+				user << "\blue You remove the vice from [M]."
+				var/wine2unholy = M.reagents.get_reagent_amount("ethanol/wine")
+				M.reagents.del_reagent("ethanol/wine")
+				M.reagents.add_reagent("unholywater",wine2unholy)
 			return
 		M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit
 		for(var/mob/O in viewers(M, null))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -534,10 +534,10 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				var/holy2unholy = M.reagents.get_reagent_amount("holywater")
 				M.reagents.del_reagent("holywater")
 				M.reagents.add_reagent("unholywater",holy2unholy)
-			if(M.reagents && M.reagents.has_reagent("ethanol/wine")) //allows cultists to be rescued from the clutches of ordained religion
+			if(M.reagents && M.reagents.has_reagent("wine"))
 				user << "\blue You remove the vice from [M]."
-				var/wine2unholy = M.reagents.get_reagent_amount("ethanol/wine")
-				M.reagents.del_reagent("ethanol/wine")
+				var/wine2unholy = M.reagents.get_reagent_amount("wine")
+				M.reagents.del_reagent("wine")
 				M.reagents.add_reagent("unholywater",wine2unholy)
 			return
 		M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -106,10 +106,10 @@ var/list/sacrificed = list()
 				if(M.stat==2)
 					continue
 				for(var/mob/living/carbon/C in orange(1,src))
-					if(iscultist(C) && !C.stat)		//converting requires three cultists
+					if(iscultist(C) && !C.stat)		//converting requires two cultists
 						cultsinrange += C
 						C.say("Mah[pick("'","`")]weyh pleggh at e'ntrath!")
-				if(cultsinrange.len >= 3)
+				if(cultsinrange.len >= 2)
 					M.visible_message("\red [M] writhes in pain as the markings below him glow a bloody red.", \
 					"\red AAAAAAHHHH!.", \
 					"\red You hear an anguished scream.")

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3033,6 +3033,33 @@ datum
 			color = "#7E4043" // rgb: 126, 64, 67
 			boozepwr = 45
 
+			on_mob_life(var/mob/living/M as mob)
+				if(!data) data = 1
+				data++
+				M.jitteriness = max(M.jitteriness-5,0)
+				if(data >= 30)		// 12 units, 54 seconds @ metabolism 0.4 units & tick rate 1.8 sec
+					if(iscultist(M) && prob(5))
+						M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","Egkau'haom'nai en Chaous","Ho Diak'nos tou Ap'iron","R'ge Na'sie","Diabo us Vo'iscum","Si gn'um Co'nu"))
+				if(data >= boozepwr)
+					if (!M.stuttering) M.stuttering = 1
+					M.stuttering += 4
+					M.Dizzy(5)
+				if(data >= boozepwr*2.5 && prob(33))
+					if (!M.confused) M.confused = 1
+					M.confused += 3
+				if(data >= 75 && prob(33))	// 30 units, 135 seconds
+					if(iscultist(M))
+						ticker.mode.remove_cultist(M.mind)
+						holder.remove_reagent(src.id, src.volume)
+						M.jitteriness = 0
+						M.stuttering = 0
+						M.confused = 0
+				holder.remove_reagent(src.id, 0.4)
+				if(data >= boozepwr*10 && prob(33))
+					M.adjustToxLoss(2)
+				..()
+				return
+
 		ethanol/cognac
 			name = "Cognac"
 			id = "cognac"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3057,7 +3057,6 @@ datum
 				holder.remove_reagent(src.id, 0.4)
 				if(data >= boozepwr*10 && prob(33))
 					M.adjustToxLoss(2)
-				..()
 				return
 
 		ethanol/cognac


### PR DESCRIPTION
1) Reduced the numbers required to convert crew members from 3 to 2.

2) Wine deconverts in the same way and quantity as holy water.

3) Wine can be cleansed from body (and converted to unholy water) by cultists in the same way as holy water.