### PR TITLE
Implemented Multi-Engine Framework

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -234,7 +234,8 @@ obj/machinery/atmospherics/pipe
 
 
 			var/turf/T = src.loc			// hide if turf is not intact
-			hide(T.intact)
+			if(T)
+				hide(T.intact)
 			update_icon()
 			//update_icon()
 
@@ -742,7 +743,8 @@ obj/machinery/atmospherics/pipe
 						break
 
 			var/turf/T = src.loc			// hide if turf is not intact
-			hide(T.intact)
+			if(T)
+				hide(T.intact)
 			//update_icon()
 			update_icon()
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -130,6 +130,8 @@
 
 	var/faction_change_delay = 24 // In hours
 
+	var/random_engine = 0 //Whether or not to use one of the random engine templates. If 0, will use whatever the prebuilt engine on the station is.
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for(var/T in L)
@@ -393,6 +395,8 @@
 					config.default_laws				= text2num(value)
 				if("join_with_mutant_race")
 					config.mutant_races				= 1
+				if("randomize_engine_template")
+					config.random_engine			= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -94,8 +94,12 @@ datum/controller/game_controller/proc/setup_engineering()
 	sleep(-1)
 	var/area/engine/alternate/A
 	var/area/mainengine = locate(/area/engine/engineering)
-
-	A = locate(pick(typesof(/area/engine/alternate) - /area/engine/alternate)) // Choose one of the alternates. Not the best way, but it will work as long as every defined alternate is on the map.
+	var/list/alternates = (typesof(/area/engine/alternate) - /area/engine/alternate)
+	if(alternates.len)
+		A = locate(pick(alternates)) // Choose one of the alternates.
+	else
+		world << "\red \b No Alternates found, reverting to lame mode..."
+		return
 
 	for(var/E in mainengine)
 		qdel(E) // Delete the default before we copy things over. Don't want to accidentally have any duplicate things now do we?

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -75,10 +75,68 @@ datum/controller/game_controller/proc/setup()
 	setup_objects()
 	setupgenetics()
 	setupfactions()
+	setup_engineering()
 
 	spawn(0)
 		if(ticker)
 			ticker.pregame()
+
+datum/controller/game_controller/proc/setup_engineering()
+	if(!config.random_engine)  //Enable this setup using the config option "randomize_engine_template"
+		for(var/B in typesof(/area/engine/alternate))
+			var/template = locate(B)
+			for(var/C in template)
+				qdel(C) // Cleaning up to reduce residual lag
+		return
+
+	world << "\red \b Randomizing world..."
+
+	sleep(-1)
+	var/area/engine/alternate/A
+	var/area/mainengine = locate(/area/engine/engineering)
+
+	A = locate(pick(typesof(/area/engine/alternate) - /area/engine/alternate)) // Choose one of the alternates. Not the best way, but it will work as long as every defined alternate is on the map.
+
+	for(var/E in mainengine)
+		qdel(E) // Delete the default before we copy things over. Don't want to accidentally have any duplicate things now do we?
+
+	A.move_contents_to(mainengine) // Move everything from the template
+
+	for(var/turf/simulated/wall/wall in world)
+		wall.relativewall() // Reconnect all walls moved
+
+	for(var/obj/machinery/atmospherics/pipe/simple/M in world)
+		M.initialize()
+		M.build_network() //Re-attach all the now moved atmos pipes.
+		if(M.node1)
+			M.node1.initialize()
+			M.node1.build_network()
+		if(M.node2)
+			M.node2.initialize()
+			M.node2.build_network()
+
+	for(var/obj/machinery/atmospherics/pipe/manifold/M in world)
+		M.initialize()
+		M.build_network() //Re-attach all the now moved atmos pipes.
+		if(M.node1)
+			M.node1.initialize()
+			M.node1.build_network()
+		if(M.node2)
+			M.node2.initialize()
+			M.node2.build_network()
+		if(M.node3)
+			M.node3.initialize()
+			M.node3.build_network()
+
+	for(var/B in typesof(/area/engine/alternate))
+		var/template = locate(B)
+		for(var/C in template)
+			qdel(C) // Cleaning up to reduce residual lag
+
+	makepowernets() // Reconnect the cables now that they've moved
+
+	sleep(-1)
+
 
 datum/controller/game_controller/proc/setup_objects()
 	world << "\red \b Initializing objects..."

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -58,6 +58,7 @@ proc/process_teleport_locs()
 	for(var/area/AR in world)
 		if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station)) continue
 		if(teleportlocs.Find(AR.name)) continue
+		if(!get_area_turfs(AR.type)) continue // If there's nothing to do here, do nothing.
 		var/turf/picked = pick(get_area_turfs(AR.type))
 		if (picked.z == 1)
 			teleportlocs += AR.name

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -847,8 +847,12 @@ proc/process_ghost_teleport_locs()
 
 //Alternate is the subgroup for the randomized engine templates.
 
-/area/engine/alternate/singularity
+/area/engine/alternate
 	icon_state = "engine"
+
+/area/engine/alternate/singularity
+
+/area/engine/alternate/thermal
 
 /area/engine/engine_smes
 	name = "\improper Engineering SMES"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -845,6 +845,11 @@ proc/process_ghost_teleport_locs()
 /area/engine
 	ambientsounds = list('sound/ambience/ambisin1.ogg','sound/ambience/ambisin2.ogg','sound/ambience/ambisin3.ogg','sound/ambience/ambisin4.ogg')
 
+//Alternate is the subgroup for the randomized engine templates.
+
+/area/engine/alternate/singularity
+	icon_state = "engine"
+
 /area/engine/engine_smes
 	name = "\improper Engineering SMES"
 	icon_state = "engine_smes"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -190,3 +190,10 @@ DEFAULT_LAWS 0
 
 ## Uncoment to give players the choice of their mutantrace before they join the game
 #JOIN_WITH_MUTANT_RACE
+
+### RANDOMIZED ENGINE ###
+## Allows usage of multiple "template" engines, allowing a random engine to be picked at every roundstart. For now all engines have equal chance.
+## If this is used without any template engines on the map, it will literally result in engineering being deleted at round start. Template engines can be anywhere on the map, and will be deleted after engineering is set up.
+## Uncomment to enable.
+#RANDOMIZE_ENGINE_TEMPLATE
+


### PR DESCRIPTION
- New defined areas to support defining as many template engines as desired
- Config option "randomize_engine_template" must be inserted into game_options.txt to enable the framework (only do this if at least 1 template is defined)
- Each new template will require its own child area of /engine/alternate/
- The "default" engine will always be whatever is already on the station map. Templates overwrite this if used.
- Each template must contain 100% of what should be in main engineering and the shape of all templates must match the engineering area.
- Any unused templates are erased during setup, even if the option is disabled. This reduces lag during game and prevents accidental spawning on them.