### PR TITLE
Visible messages when borgs equip weapons

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -137,6 +137,8 @@
 				inv2.icon_state = "inv2"
 				inv3.icon_state = "inv3"
 				module_active = module_state_1
+				if(istype(module_active,/obj/item/device/flash) || istype(module_active,/obj/item/weapon/melee/baton) || istype(module_active,/obj/item/weapon/gun/energy/taser) || istype(module_active,/obj/item/weapon/razor) || istype(module_active,/obj/item/device/violin))
+					visible_message("\red [src] extends \icon[module_active] [module_active]")
 				return
 		if(2)
 			if(module_active != module_state_2)
@@ -144,6 +146,8 @@
 				inv2.icon_state = "inv2 +a"
 				inv3.icon_state = "inv3"
 				module_active = module_state_2
+				if(istype(module_active,/obj/item/device/flash) || istype(module_active,/obj/item/weapon/melee/baton) || istype(module_active,/obj/item/weapon/gun/energy/taser) || istype(module_active,/obj/item/weapon/razor) || istype(module_active,/obj/item/device/violin))
+					visible_message("\red [src] extends \icon[module_active] [module_active]")
 				return
 		if(3)
 			if(module_active != module_state_3)
@@ -151,6 +155,8 @@
 				inv2.icon_state = "inv2"
 				inv3.icon_state = "inv3 +a"
 				module_active = module_state_3
+				if(istype(module_active,/obj/item/device/flash) || istype(module_active,/obj/item/weapon/melee/baton) || istype(module_active,/obj/item/weapon/gun/energy/taser) || istype(module_active,/obj/item/weapon/razor) || istype(module_active,/obj/item/device/violin))
+					visible_message("\red [src] extends \icon[module_active] [module_active]")
 				return
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -149,7 +149,8 @@
 	name = "security robot module"
 
 	New()
-		..()
+		modules += new /obj/item/device/flashlight/seclite(src)
+		modules += new /obj/item/device/flash(src)
 		modules += new /obj/item/borg/sight/hud/sec(src)
 		modules += new /obj/item/weapon/handcuffs/cyborg(src)
 		modules += new /obj/item/weapon/melee/baton/loaded(src)


### PR DESCRIPTION
Visible messages when borgs equip weapons
Gives the security borgs a seclite instead of a flashlight

![ss 2015-01-31 at 06 47 14](https://cloud.githubusercontent.com/assets/6185415/5987944/01420130-a915-11e4-9b8d-5071eb1dc42d.png)
