### PR TITLE
Pizza, Carpet, and Wood added to cargo ordering

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -874,6 +874,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	containername = "glass sheets crate"
 
+/datum/supply_packs/materials/wood30
+	name = "30 Wood Sheets"
+	contains = list(/obj/item/stack/sheet/mineral/wood)
+	amount = 30
+	cost = 10
+	containername = "wood sheet crate"
+
 /datum/supply_packs/materials/cardboard50
 	name = "50 Cardboard Sheets"
 	contains = list(/obj/item/stack/sheet/cardboard)
@@ -888,6 +895,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 20
 	containername = "sandstone blocks crate"
 
+/datum/supply_packs/materials/carpet50
+	name = "50 Carpet Tiles"
+	contains = list(/obj/item/stack/tile/carpet)
+	amount = 50
+	cost = 20
+	containername = "carpet crate"
+
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
@@ -896,6 +910,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 /datum/supply_packs/misc
 	name = "HEADER"
 	group = supply_misc
+
+//"Hello? Pizza delivery for, uh ... I.C. Wiener?"
+/datum/supply_packs/misc/randomised/pizza
+	name = "Pizza Delivery"
+	num_contained = 1
+	contains = list(/obj/item/pizzabox/margherita,
+					/obj/item/pizzabox/meatpizza,
+					/obj/item/pizzabox/mushroompizza,
+					/obj/item/pizzabox/vegetablepizza,)
+	cost = 15
+	containername = "pizza crate"
 
 /datum/supply_packs/misc/mule
 	name = "MULEbot Crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -916,9 +916,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "Pizza Delivery"
 	num_contained = 1
 	contains = list(/obj/item/pizzabox/margherita,
-					/obj/item/pizzabox/meatpizza,
-					/obj/item/pizzabox/mushroompizza,
-					/obj/item/pizzabox/vegetablepizza,)
+			/obj/item/pizzabox/meatpizza,
+			/obj/item/pizzabox/mushroompizza,
+			/obj/item/pizzabox/vegetablepizza,)
 	cost = 15
 	containername = "pizza crate"
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2218,6 +2218,24 @@
 	var/list/boxes = list() // If the boxes are stacked, they come here
 	var/boxtag = ""
 
+/obj/item/pizzabox/margherita
+	name = "margherita pizza box"
+	New()
+		pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita(src)
+/obj/item/pizzabox/meatpizza
+	name = "meat pizza box"
+	New()
+		pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/meatpizza(src)
+/obj/item/pizzabox/mushroompizza
+	name = "mushroom pizza box"
+	New()
+		pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza(src)
+/obj/item/pizzabox/vegetablepizza
+	name = "vegetable pizza box"
+	New()
+		pizza = new /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza(src)
+
+
 /obj/item/pizzabox/update_icon()
 	overlays = list()
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -62,6 +62,8 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h3 class="author">FlavoredCactus updated:</h3>
 	<ul class="changes bgimages16">
 		<li class="rscadd">Animations added to attacks, being tased, and lack of gravity</li>
+		<li class="rscadd">Cargo can now order wood and carpet</li>
+		<li class="rscadd">Pizza Delivery option added to Misc in cargo</li>
 		<li class="tweak">Reverted permabrig doors to vanilla settings (No airlock control,bolts)</li>
 	</ul>
 	<h3 class="author">QuantumWings updated:</h3>


### PR DESCRIPTION
Cargo can now order wood(30 sheets) and carpet(50 sheets) as well as ordering a Pizza Delivery