### PR TITLE
Player Analysis Panel Updated

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -102,4 +102,5 @@ proc/add_logs(mob/user, mob/target, what_done, var/admin=1, var/object=null, var
 	if(target && ismob(target))
 		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [what_done] by [user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition]</font>")
 	if(admin)
+
 		log_attack("<font color='red'>[user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"] [what_done] [target ? "[target.name][(ismob(target) && target.ckey)? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition]</font>")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -338,12 +338,14 @@ proc/display_roundstart_age_report()
 // This proc was once to check if the player logged on and logged off, on other servers logging out is against the rules so we didn't
 //really need this proc, i have replaced it to tell admins the players who have recently started playing on the server so we could
 //properlly greet them and welcome them on and help them if they seem to be causing trouble
-	var/msg = "\blue <b>Roundstart player age report\n\n"
+	var/msg = "\blue <b>Roundstart player report\n\n"
+	var/found
 	for(var/mob/L in mob_list)
 		if(L.client)
-			var/age = text2num(L.client.player_age)
-			if(age <= 14)
-				msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Player age: <font color = 'red'>[age]</font>)\n"
+			if(!L.client.prefs.knownplayer)
+				found++
+	if(found)
+		msg += "<b><font color = 'red'>[found]</font> unknown player(s) found (use player analysis panel for details)\n"
 
 	for(var/mob/M in mob_list)
 		if(M.client && M.client.holder)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -48,7 +48,14 @@ var/global/floorIsLava = 0
 		body += " <B>Hasn't Entered Game</B> "
 	else
 		body += " \[<A href='?_src_=holder;revive=\ref[M]'>Heal</A>\] "
-
+	if(M.client)
+		if(M.client.prefs.knownplayer)
+			body += "<br><br>Known Player: "
+			body += " [M.client.prefs.knownplayer ? "<b>[M.client.prefs.knownplayer]</b>" : "Unknown"] "
+			body += "\[<A href='?_src_=holder;knownedit=\ref[M]'>Edit Details</A>\]"
+		if(!M.client.prefs.knownplayer)
+			body += "<br><br><b><u>Unknown Player!</b></u> "
+			body += "\[<A href='?_src_=holder;knownedit=\ref[M]'>Tag As Known</A>\]"
 	body += "<br><br>\[ "
 	body += "<a href='?_src_=vars;Vars=\ref[M]'>VV</a> - "
 	body += "<a href='?_src_=holder;traitor=\ref[M]'>TP</a> - "

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -763,6 +763,19 @@
 			//M.client = null
 			del(M.client)
 
+	else if(href_list["knownedit"])
+		var/mob/M = locate(href_list["knownedit"])
+		if (ismob(M))
+			if(M.client)
+				var/t = input("Enter a small detail about the player", "Write", M.client.prefs.knownplayer, null) as text
+				if(!t)
+					M.client.prefs.knownplayer = ""
+					M.client.prefs.save_nonpreferences()
+				if(t)
+					M.client.prefs.knownplayer = "[t] ~[usr.ckey]"
+					M.client.prefs.save_nonpreferences()
+					message_admins("\blue [key_name_admin(usr)] tagged [M.ckey] as known. Details: [M.client.prefs.knownplayer]", 1)
+
 	//Player Notes
 	else if(href_list["notes"])
 		var/ckey = href_list["ckey"]

--- a/code/modules/admin/verbs/alt_check.dm
+++ b/code/modules/admin/verbs/alt_check.dm
@@ -5,12 +5,22 @@
 	var/dat = {"<B>Just to be sure you should try to also look up computer IDs/IPs on the server logs for a second opinion.</B>
 				<br>Additionally make an attempt to introduce new players to the server
 				<HR>"}
-
 	for(var/client/C in clients)
-		dat += "<p>[C.ckey] (Player Age: <font color = 'red'>[C.player_age]</font>) - <b>[C.computer_id]</b> / <b>[C.address]</b><br>"
+		if(!prefs.knownplayer)
+			dat += "Unknown Players (Click to tag):<br>"
+			break
+	for(var/client/C in clients)
+		if(!prefs.knownplayer)
+			dat += "<A href='?_src_=holder;knownedit=\ref[C.mob]'>[C.ckey]</a><br>"
+
+	dat += "<br><br>Player Data:"
+	for(var/client/C in clients)
+		dat += "<p>[C.ckey] <A href='?_src_=holder;notes=show;ckey=[C.ckey]'>(Notes)</A> (Player Age: <font color = 'red'>[C.player_age]</font>) - <b>[C.computer_id]</b> / <b>[C.address]</b><br>"
 		if(C.alt_count >= 2)
 			dat += "--Accounts associated with CID: <b>[C.related_accounts_cid]</b><br>"
 			dat += "--Accounts associated with IP: <b>[C.related_accounts_ip]</b><br>"
+		if(C.prefs.knownplayer)
+			dat += "--Known Details: <b>[C.prefs.knownplayer]</b> <A href='?_src_=holder;knownedit=\ref[C.mob]'>Edit</a><br>"
 	usr << browse(dat, "window=alt_panel;size=640x480")
 	return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -31,6 +31,7 @@ datum/preferences
 	var/muted = 0
 	var/last_ip
 	var/last_id
+	var/knownplayer = ""	//Admins can mark players as known or unknown, by default is unknown
 
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
@@ -97,6 +98,7 @@ datum/preferences
 			if(unlock_content)
 				max_save_slots = 8
 	var/loaded_preferences_successfully = load_preferences()
+	load_nonpreferences()
 	if(loaded_preferences_successfully)
 		if(load_character())
 			return

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -265,6 +265,46 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	return 1
 
+///Non-prefrence saving
+//For now it is used to save the known player variable but you could use it for like karma points or something in the future - Flavo
+
+/datum/preferences/proc/load_nonpreferences()
+	if(!path)				return 0
+	if(!fexists(path))		return 0
+
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	var/needs_update = savefile_needs_update(S)
+	if(needs_update == -2)		//fatal, can't load any data
+		return 0
+
+	//non-preferences
+	S["knownplayer"]			>> knownplayer
+
+	//try to fix any outdated data if necessary
+	if(needs_update >= 0)
+		update_preferences(needs_update)		//needs_update = savefile_version if we need an update (positive integer)
+
+	//Sanitize
+	knownplayer 	= sanitize_text(knownplayer, initial(knownplayer))
+
+	return 1
+
+/datum/preferences/proc/save_nonpreferences()
+	if(!path)				return 0
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	S["version"] << SAVEFILE_VERSION_MAX		//updates (or failing that the sanity checks) will ensure data is not invalid at load. Assume up-to-date
+
+	//non-preferences
+	S["knownplayer"]			<< knownplayer
+
+	return 1
+
 
 #undef SAVEFILE_VERSION_MAX
 #undef SAVEFILE_VERSION_MIN


### PR DESCRIPTION
You can now tag players as known/unknown, by default they start unknown.
when you tag you add a small detail

FlavoredCactus
Unknown

FlavoredCactus
Known: Can be a bit powergamey, but no issues here. knows space law and
stuff.


What makes this different from notes is at round start there will be a little admin alert "5 unknown players on the server (see player analysis panel for details) and upon opening it you get the list of unknown players. youl be able to run through the list and start marking known players and if you see one you dont know you can use this as incentive to find out what they are like and probably introduce them to the server.