### PR TITLE
Medborg hypospray's reagents change

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -23,8 +23,8 @@ Borg Hypospray
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list("doctorsdelight", "inaprovaline", "spaceacillin")
-	//var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "anti_toxin", "inaprovaline", "spaceacillin")
+	//var/list/reagent_ids = list("doctorsdelight", "inaprovaline", "spaceacillin")
+	var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "anti_toxin", "inaprovaline", "tricordrazine")
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
 


### PR DESCRIPTION
Medical Cyborg gets dexalin, kelotane, bicaridine, antitox, inaprovaline and tricordrazine in its hypospray, instead of doc's delight, inaprovaline and spaceacillin.