### PR TITLE
Security berets ear_safety

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -37,7 +37,7 @@
 			takes_eye_damage = 1
 			var/mob/living/carbon/human/H = C
 			ear_safety = 0
-			if(istype(H.ears, /obj/item/clothing/ears/earmuffs) || istype(H.head, /obj/item/clothing/head/helmet))
+			if(istype(H.ears, /obj/item/clothing/ears/earmuffs) || istype(H.head, /obj/item/clothing/head/helmet) || istype(H.head, /obj/item/clothing/head/beret/sec))
 				ear_safety++
 		if(ismonkey(C))
 			ear_safety = 0


### PR DESCRIPTION
Included security berets in flashang's ear_safety check, so they protect against its bang.