### PR TITLE
Admin stuff

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -8,7 +8,7 @@
 	var/list/Lines = list()
 
 	if(holder)
-		if(check_rights(R_ADMIN,0))//If they have +ADMIN, show hidden admins, player IC names and IC status
+		if(check_rights(R_ADMIN,0) && admintoggles)//If they have +ADMIN, show hidden admins, player IC names and IC status
 			for(var/client/C in clients)
 				var/entry = "\t[C.key]"
 				if(C.holder && C.holder.fakekey)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -216,6 +216,9 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/debug_variables,
 	/client/proc/cmd_admin_delete,
 	/client/proc/Jump,
+	/client/proc/Getmob,
+	/client/proc/cmd_admin_pm_context,
+	/datum/admins/proc/show_player_panel,
 	/proc/possess,
 	/proc/release
 	)


### PR DESCRIPTION
-If "Hide admin messages" is on, the who verb will return the list of
players + number of players rather then antag status and whos dead or
not
-Getmob, PM mob, and Show player panel added to "Hide Most" list. you
can still do these things they just wont show up in right click or
object tab.