### PR TITLE
Fixed Bluespace Anomaly Event

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -74,4 +74,4 @@
 								sleep(20)
 								M.client.screen -= blueeffect
 								qdel(blueeffect)
-			qdel(newAnomaly)
+		qdel(newAnomaly)


### PR DESCRIPTION
Bug: Bluespace Anomaly occurs even after the anomaly is gone
Fix: Corrected indentation to bring end() in line with other anomalies.