### PR TITLE
Mining Cyborg Jetpack Fix

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -151,7 +151,7 @@
 		usr << "There's no mounting point for the module!"
 		return 0
 	else
-		R.module.modules += new/obj/item/weapon/tank/jetpack/carbondioxide
+		R.module.modules += new/obj/item/weapon/tank/jetpack/carbondioxide(R.module)
 		for(var/obj/item/weapon/tank/jetpack/carbondioxide in R.module.modules)
 			R.internals = src
 		R.icon_state="Miner+j"


### PR DESCRIPTION
Fix for #250

Mining cyborg jetpack is now properly stored in the contents of the
cyborg module like all the other cyborg module items.

Previously failed a check done in /code/game/objects/items.dm in the
attack_ai() proc.

Problem found, traced, fixed, and tested.