### PR TITLE
Comments out SQL_ENABLED by default

### DIFF
--- a/code/modules/admin/ahelp_panel.dm
+++ b/code/modules/admin/ahelp_panel.dm
@@ -189,18 +189,18 @@
 
 					</tr>
 				"}
+	if(config.sql_enabled)
+		for(var/datum/admin_conversation/A in GetCurrentAdminConversations())
 
-	for(var/datum/admin_conversation/A in GetCurrentAdminConversations())
-
-		dat += {"
-				<tr>
-					<td><center>[A.GetPlayerCkey()]</center></td>
-					<td><center>[A.original_adminhelp]</center></td>
-					<td><center><a href='[A.GetLink()]' target='_blank'>View In Browser</a></center></td>
-				</tr>
-				<br>
-				</font>
-				"}
+			dat += {"
+					<tr>
+						<td><center>[A.GetPlayerCkey()]</center></td>
+						<td><center>[A.original_adminhelp]</center></td>
+						<td><center><a href='[A.GetLink()]' target='_blank'>View In Browser</a></center></td>
+					</tr>
+					<br>
+					</font>
+					"}
 
 	dat += "</table>"
 

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,7 +3,7 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable.
-SQL_ENABLED
+#SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.


### PR DESCRIPTION
Fixs runtimer error with "View Admin helps" when SQL is not enabled.

was causing problems with adimhelping/crashs on test servers.