### PR TITLE
Fixs guest job bans

### DIFF
--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -18,12 +18,12 @@ var/jobban_keylist[0]		//to store the keys & ranks
 	if(M && rank)
 		/*
 		if(_jobban_isbanned(M, rank)) return "Reason Unspecified"	//for old jobban
+		*/
 		if (guest_jobbans(rank))
 			if(config.guest_jobban && IsGuestKey(M.key))
 				return "Guest Job-ban"
 			if(config.usewhitelist && !check_whitelist(M))
 				return "Whitelisted Job"
-		*/
 		for (var/s in jobban_keylist)
 			if( findtext(s,"[M.ckey] - [rank]") == 1 )
 				var/startpos = findtext(s, "## ")+3


### PR DESCRIPTION
Our server uses the GUEST_JOBBAN config option but it doesnt actually
work. this is because the check for guests and guest job bans were
commented out.

tested the following:
-Guests cannot play as head/sec/AI roles
-Was able to play as these roles by using an account
-Did not break job bans. could sill apply them.