### PR TITLE
Fixes Energy based guns using charge without being fired

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -38,15 +38,19 @@
 
 
 /obj/item/weapon/gun/energy/proc/newshot()
-	if (!ammo_type || !power_supply)	return
+	if (!ammo_type || !power_supply)
+		return
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if (!power_supply.use(shot.e_cost))	return
-	chambered = shot
-	chambered.newshot()
+	if(power_supply.charge >= shot.e_cost) //if there's enough power in the power_supply cell...
+		chambered = shot //...prepare a new shot based on the current ammo type selected
+		chambered.newshot()
 	return
 
 /obj/item/weapon/gun/energy/process_chamber()
-	chambered = null
+	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
+		var/obj/item/ammo_casing/energy/shot = chambered
+		power_supply.use(shot.e_cost)//... drain the power_supply cell
+	chambered = null //either way, released the prepared shot
 	return
 
 /obj/item/weapon/gun/energy/proc/select_fire(mob/living/user as mob)


### PR DESCRIPTION
code taken from tgstation's fix:
The new procedure goes as follow :
the click code goes on until its end (afterattack),
if there's enough energy in the gun cell, a selected mode shot is
chambered (laser, electrode, ...),
the attack/firing code does its things,
at the end of it, we check if the shot was spent (i.e the actual
"bullet" was send). If so, we draw on the gun cell the correct amount of
power. If not, we just discard the chambered shot.