### PR TITLE
Admin verb to re-enable the gravgen.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -116,7 +116,7 @@
 	icon_state = "toxpack"
 
 /obj/item/weapon/storage/backpack/botany
-	name = "medical backpack"
+	name = "botany backpack"
 	desc = "A green backpack for plant related work."
 	icon_state = "botanypack"
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -12,14 +12,14 @@ var/global/floorIsLava = 0
 			X << msg
 		X.send_text_to_tab(msg, "asay")
 
-///////Toggle ahelp/asay/alogs///////
+///////Toggle ahelp/alogs///////
 
 /client/proc/toggleahelp()
 	set name = "Show/Hide Admin Messages"
 	set category = "Preferences"
-	set desc ="Toggles seeing adminhelps/asay/alogs"
+	set desc ="Toggles seeing adminhelps/alogs"
 	admintoggles = !admintoggles
-	src << "You will [admintoggles ? "now" : "no longer"] see admin helps, admin logs, or asay."
+	src << "You will [admintoggles ? "now" : "no longer"] see admin helps, or admin logs."
 	feedback_add_details("admin_verb","TAH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /////////////////////////////////////

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -68,7 +68,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/createPerseusMission,
 	/proc/Ban_Offline_Player,
 	/client/proc/fill_breach,
-	/client/proc/fix_gravity,
+	/client/proc/reenable_gravity_gen,
 	/client/proc/spawncostume
 	//+Sound
 	)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -68,6 +68,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/createPerseusMission,
 	/proc/Ban_Offline_Player,
 	/client/proc/fill_breach,
+	/client/proc/fix_gravity,
 	/client/proc/spawncostume
 	//+Sound
 	)

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -17,8 +17,7 @@
 		msg_to_send = "<span class='adminobserver'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]:</EM> <span class='message'>[msg]</span></span>"
 
 	for(var/client/admin in admins)
-		if(admin.admintoggles)
-			admin << msg_to_send
+		admin << msg_to_send
 		admin.send_text_to_tab(msg_to_send, "asay")
 
 	feedback_add_details("admin_verb","M") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -828,6 +828,23 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name(src)] cleaned air within [size] tiles.")
 	log_game("[key_name(src)] cleaned air within [size] tiles.")
 
+/client/proc/fix_gravity()
+	set name = "Turn on gravity"
+	set category = "Special Verbs"
+	set desc = "Use this when griefons turn off the gravity gen "
+	for(var/obj/machinery/gravity_generator/main/grav in world)
+		if(grav.z == 1) // make sure the grav gen is in z 1
+			grav.breaker = 1
+			grav.charge_count = 100
+			grav.set_state(1) // Turn it on!!
+			if(grav.middle)
+				grav.middle.overlays.Cut() // Update the overlay
+				grav.middle.overlays += "activated"
+				grav.current_overlay = "activated"
+			break
+	message_admins("[key_name(src)] admin revived the gravity generator")
+	log_game("[key_name(src)] admin revived the gravity generator")
+
 /client/proc/fill_breach()
 	set name = "Fill Hull Breach"
 	set category = "Special Verbs"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -828,17 +828,17 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name(src)] cleaned air within [size] tiles.")
 	log_game("[key_name(src)] cleaned air within [size] tiles.")
 
-/client/proc/fix_gravity()
-	set name = "Turn on gravity"
+/client/proc/reenable_gravity_gen()
+	set name = "Turn on Gravity Generator"
 	set category = "Special Verbs"
-	set desc = "Use this when griefons turn off the gravity gen "
+	set desc = "Use this to turn on the gravity generator"
 	for(var/obj/machinery/gravity_generator/main/grav in world)
-		if(grav.z == 1) // make sure the grav gen is in z 1
+		if(grav.z == 1)
 			grav.breaker = 1
 			grav.charge_count = 100
-			grav.set_state(1) // Turn it on!!
+			grav.set_state(1)
 			if(grav.middle)
-				grav.middle.overlays.Cut() // Update the overlay
+				grav.middle.overlays.Cut()
 				grav.middle.overlays += "activated"
 				grav.current_overlay = "activated"
 			break

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -242,6 +242,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	if(href_list["gentoggle"])
 		breaker = !breaker
 		investigate_log("was toggled [breaker ? "<font color='green'>ON</font>" : "<font color='red'>OFF</font>"] by [usr.key].", "gravity")
+		message_admins("[key_name(usr, usr.client)] [breaker ? "<font color='green'>enabled</font>" : "<font color='red'>disabled</font>"] the gravity generator!")
 		set_power()
 		src.updateUsrDialog()
 


### PR DESCRIPTION
-admin message when someone shuts off the GravGen
-Fixs a backpack's incorrect name
-Asay will now always be enabled despite admin messages being turned
off. deadmin if you dont wish to see asay


![](http://i.imgur.com/6D8ETpa.gif)
