### PR TITLE
Restores Old Mesons

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -5,12 +5,13 @@
 	item_state = "glasses"
 	origin_tech = "magnets=2;engineering=2"
 	vision_flags = SEE_TURFS
-
+	invis_view = SEE_INVISIBLE_MINIMUM
+/*
 /obj/item/clothing/glasses/meson/advanced
 	name = "Advanced Optical Meson Scanner"
 	desc = "More powerful than your standard mesons, these ones make everything appear to be lit extremely brightly."
 	invis_view = SEE_INVISIBLE_MINIMUM
-
+*/
 /obj/item/clothing/glasses/science
 	name = "Science Goggles"
 	desc = "nothing"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1921,7 +1921,7 @@ datum/design/mesons
 	build_type = PROTOLATHE
 	materials = list("$metal" = 50, "$glass" = 50)
 	build_path = /obj/item/clothing/glasses/meson
-
+/*
 datum/design/advanced_mesons
 	name = "Advanced Optical Meson Scanner"
 	desc = "More powerful than your standard mesons, these ones make everything appear to be lit extremely brightly."
@@ -1930,7 +1930,7 @@ datum/design/advanced_mesons
 	build_type = PROTOLATHE
 	materials = list("$metal" = 100, "$glass" = 100)
 	build_path = /obj/item/clothing/glasses/meson/advanced
-
+*/
 datum/design/night_vision_goggles
 	name = "Night Vision Goggles"
 	desc = "Goggles that let you see through darkness unhindered."


### PR DESCRIPTION


![](http://i.imgur.com/jvrzBJA.gif)
Removal of advance mesons and putting the classic meson vision on the
normal mesons

This pull request simply puts the code for "Advance Mesons" onto the regular mesons. Nothing else.
You still don't see mobs or objs, if you have no light. Only turf.

I feel like mesons right now are pretty much pointless to any engineer and only serves a purpose to shaft miners to see things with the mining scanner

This is:
Bringing back the classic mesons

This is not:
Bringing back old mining (you cannot see plasma,uranium)
Giving people night vision 