### PR TITLE
Traitor Objective: 'Die a Glorious Death'

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -369,7 +369,7 @@ datum/mind
 				if(!def_value)//If it's a custom objective, it will be an empty string.
 					def_value = "custom"
 
-			var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "debrain", "protect", "prevent", "hijack", "escape", "survive", "steal", "download", "nuclear", "capture", "absorb", "custom")
+			var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "maroon", "debrain", "protect", "destroy", "prevent", "hijack", "escape", "survive", "martyr", "steal", "download", "nuclear", "capture", "absorb", "custom")
 			if (!new_obj_type) return
 
 			var/datum/objective/new_objective = null
@@ -421,6 +421,10 @@ datum/mind
 
 				if ("survive")
 					new_objective = new /datum/objective/survive
+					new_objective.owner = src
+
+				if("martyr")
+					new_objective = new /datum/objective/martyr
 					new_objective.owner = src
 
 				if ("nuclear")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -5,6 +5,7 @@ datum/objective
 	var/target_amount = 0				//If they are focused on a particular number. Steal objectives have their own counter.
 	var/completed = 0					//currently only used for custom objectives.
 	var/dangerrating = 0				//How hard the objective is, essentially. Used for dishing out objectives and checking overall victory.
+	var/martyr_compatible = 1			//If the objective is compatible with martyr objective, i.e. if you can still do it while dead.
 
 datum/objective/New(var/text)
 	if(text)
@@ -90,6 +91,7 @@ datum/objective/mutiny/update_explanation_text()
 datum/objective/debrain//I want braaaainssss
 	var/target_role_type=0
 	dangerrating = 20
+	martyr_compatible = 0
 
 datum/objective/debrain/find_target_by_role(role, role_type=0)
 	target_role_type = role_type
@@ -149,6 +151,7 @@ datum/objective/protect/update_explanation_text()
 datum/objective/hijack
 	explanation_text = "Hijack the emergency shuttle by escaping alone."
 	dangerrating = 25
+	martyr_compatible = 0
 
 datum/objective/hijack/check_completion()
 	if(!owner.current || owner.current.stat)
@@ -198,6 +201,7 @@ datum/objective/block/check_completion()
 datum/objective/escape
 	explanation_text = "Escape on the shuttle or an escape pod alive."
 	dangerrating = 5
+	martyr_compatible = 0
 
 datum/objective/escape/check_completion()
 	if(issilicon(owner.current))
@@ -237,6 +241,7 @@ datum/objective/escape/check_completion()
 datum/objective/survive
 	explanation_text = "Stay alive until the end."
 	dangerrating = 3
+	martyr_compatible = 0
 
 datum/objective/survive/check_completion()
 	if(!owner.current || owner.current.stat == DEAD || isbrain(owner.current))
@@ -246,10 +251,22 @@ datum/objective/survive/check_completion()
 	return 1
 
 
+datum/objective/martyr
+	explanation_text = "Die a glorious death."
+	dangerrating = 1
+	martyr_compatible = 0
+
+datum/objective/martyr/check_completion()
+	if(!owner.current) //Gibbed, etc.
+		return 1
+	if(owner.current && owner.current.stat == DEAD) //You're dead! Yay!
+		return 1
+	return 0
+
 
 datum/objective/nuclear
 	explanation_text = "Destroy the station with a nuclear device."
-
+	martyr_compatible = 1
 
 
 var/global/list/possible_items = list()
@@ -257,6 +274,8 @@ datum/objective/steal
 	var/datum/objective_item/targetinfo = null //Save the chosen item datum so we can access it later.
 	var/obj/item/steal_target = null //Needed for custom objectives (they're just items, not datums).
 	dangerrating = 5 //Overridden by the individual item's difficulty, but defaults to 5 for custom objectives.
+	martyr_compatible = 0
+
 
 datum/objective/steal/New()
 	..()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -128,7 +128,7 @@
 				steal_objective.find_target()
 				traitor.objectives += steal_objective
 
-			if(prob(0)) //90% chance to get Escape
+			if(prob(90)) //90% chance to get Escape
 				if (!(locate(/datum/objective/escape) in traitor.objectives))
 					var/datum/objective/escape/escape_objective = new
 					escape_objective.owner = traitor

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -97,6 +97,7 @@
 		kill_objective.find_target()
 		traitor.objectives += kill_objective
 
+
 		var/datum/objective/survive/survive_objective = new
 		survive_objective.owner = traitor
 		traitor.objectives += survive_objective
@@ -127,13 +128,26 @@
 				steal_objective.find_target()
 				traitor.objectives += steal_objective
 
-			if(prob(90))
+			if(prob(0)) //90% chance to get Escape
 				if (!(locate(/datum/objective/escape) in traitor.objectives))
 					var/datum/objective/escape/escape_objective = new
 					escape_objective.owner = traitor
 					traitor.objectives += escape_objective
 			else
-				if (!(locate(/datum/objective/hijack) in traitor.objectives))
+
+				var/martyr_compatibility = 1
+				for(var/datum/objective/O in traitor.objectives)
+					if(!O.martyr_compatible) //You can't succeed in stealing if you're dead.
+						martyr_compatibility = 0
+						break
+
+//If you do not have an Escape objective and you have martyr-compatible objectives, you will Martyr. Otherwise, Hijack
+				if (!(locate(/datum/objective/martyr) in traitor.objectives) && martyr_compatibility == 1)
+					var/datum/objective/martyr/martyr_objective = new
+					martyr_objective.owner = traitor
+					traitor.objectives += martyr_objective
+
+				if (!(locate(/datum/objective/hijack) in traitor.objectives) && !(locate(/datum/objective/martyr) in traitor.objectives))
 					var/datum/objective/hijack/hijack_objective = new
 					hijack_objective.owner = traitor
 					traitor.objectives += hijack_objective
@@ -334,7 +348,7 @@
 		owner.objectives += backstab_objective
 
 	var/datum/objective/escape_objective
-	if(90)
+	if(prob(90))
 		escape_objective = new/datum/objective/escape
 	else
 		escape_objective = new/datum/objective/hijack


### PR DESCRIPTION
Adds Traitor objective 'Die a Glorious Death'.

This objective ('Martyr') will trigger instead of 'Hijack' if the traitor has martyr-compatible objectives; That is, the objective can still be completed if he is dead. Most often, that means assassinate, however 'Detonate Nuke' is also flagged as compatible.

Potential expansions include giving this to Wizards and Nuke Ops.