### PR TITLE
Adds fancy dress blues to Security

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -108,10 +108,7 @@
 		..()
 		sleep(2)
 		new /obj/item/clothing/suit/wintercoat/security(src)
-		if(prob(35))
-			new /obj/item/clothing/suit/armor/vest/jacket(src)
-		else
-			new /obj/item/clothing/suit/armor/vest(src)
+		new /obj/item/clothing/suit/armor/vest/jacket(src)
 		new /obj/item/clothing/suit/armor/vest(src)
 		new /obj/item/clothing/under/rank/warden(src)
 		new /obj/item/clothing/head/beret/sec(src)
@@ -131,6 +128,8 @@
 		new /obj/item/weapon/melee/baton/loaded(src)
 		new /obj/item/weapon/storage/belt/security(src)
 		new /obj/item/weapon/clipboard(src)
+		new /obj/item/clothing/under/rank/warden/navyblue(src)
+		new /obj/item/clothing/head/beret/sec/navywarden(src)
 		return
 
 
@@ -158,6 +157,8 @@
 		new /obj/item/weapon/storage/backpack/dufflebag/sec(src)
 		new /obj/item/device/flash(src)
 		new /obj/item/weapon/reagent_containers/spray/pepper(src)
+		new /obj/item/clothing/under/rank/security/navyblue(src)
+		new /obj/item/clothing/head/beret/sec/navyofficer(src)
 		return
 
 

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -1,3 +1,5 @@
+//Closets can only contain 30 items. Please be careful not to overfill them! (looking at you seclocker)
+
 /obj/structure/closet/wardrobe
 	name = "wardrobe"
 	desc = "It's a storage closet for standard-issue Nanotrasen attire."
@@ -32,17 +34,21 @@
 	new /obj/item/clothing/head/beret/sec(src)
 	new /obj/item/clothing/head/beret/sec(src)
 	new /obj/item/clothing/head/beret/sec(src)
+	new /obj/item/clothing/head/beret/sec/navyofficer(src)
+	new /obj/item/clothing/head/beret/sec/navyofficer(src)
+	new /obj/item/clothing/head/beret/sec/navyofficer(src)
+	new /obj/item/clothing/suit/armor/vest/jacket(src)
 	if(prob(30))
 		new /obj/item/clothing/suit/armor/vest/jacket(src)
-	if(prob(30))
-		new /obj/item/clothing/suit/armor/vest/jacket(src)
-	if(prob(30))
-		new /obj/item/clothing/under/camo(src)
+	new /obj/item/clothing/under/camo(src)
 	if(prob(30))
 		new /obj/item/clothing/under/camo(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/under/rank/security(src)
+	new /obj/item/clothing/under/rank/security/navyblue(src)
+	new /obj/item/clothing/under/rank/security/navyblue(src)
+	new /obj/item/clothing/under/rank/security/navyblue(src)
 	new /obj/item/clothing/shoes/jackboots(src)
 	new /obj/item/clothing/shoes/jackboots(src)
 	new /obj/item/clothing/shoes/jackboots(src)
@@ -61,9 +67,11 @@
 	new /obj/item/clothing/under/camo(src)
 	new /obj/item/clothing/suit/armor/vest/jacket(src)
 	new /obj/item/clothing/head/beret/sec(src)
+	new /obj/item/clothing/head/beret/sec/navyhos(src)
 	new /obj/item/clothing/under/hosformalfem(src)
 	new /obj/item/clothing/under/hosformalmale(src)
 	new /obj/item/clothing/under/rank/head_of_security/jensen(src)
+	new /obj/item/clothing/under/rank/head_of_security/navyblue(src)
 	return
 
 /obj/structure/closet/wardrobe/pink


### PR DESCRIPTION
Image: http://i.imgur.com/zlP1oTH.png

Security has these very nice dress shirt and blue pants alt. uniforms. Previously, they were only available by ordering them from Cargo. Now they spawn in HoS/Warden lockers, Security lockers, and Sec Wardrobes

Note that the relevant jackets were *not* included in these lockers; The jackets are unarmored and cannot hold gear on the suit storage, so I assumed nobody would want them.
Also note that the probability checks for Camopants/Mil.Jacket in Security Wardrobes have been removed; They will now always have one of each, with a 30% chance for another. Nobody's ~*style*~ should be left in the hands of an RNG