### PR TITLE
"Show/Hide OOC" command tweak

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -45,20 +45,20 @@
 
 	for(var/client/C in clients)
 		var/to_tab = ""
-		if(C.prefs.toggles & CHAT_OOC)
-			if(holder)
-				if(!holder.fakekey || C.holder)
-					if(check_rights_for(src, R_TRIALADMIN))
-						to_tab = "<font color=[config.allow_admin_ooccolor ? prefs.ooccolor :"#b82e00" ]><b><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></b></font>"
-					else
-						to_tab = "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
+		if(holder)
+			if(!holder.fakekey || C.holder)
+				if(check_rights_for(src, R_TRIALADMIN))
+					to_tab = "<font color=[config.allow_admin_ooccolor ? prefs.ooccolor :"#b82e00" ]><b><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></b></font>"
 				else
-					to_tab = "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
+					to_tab = "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
 			else
-				to_tab = "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
+				to_tab = "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
+		else
+			to_tab = "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
 
+		if(C.prefs.toggles & CHAT_OOC)
 			C << to_tab
-			C.send_text_to_tab(to_tab, "ooc")
+		C.send_text_to_tab(to_tab, "ooc")
 
 /proc/toggle_ooc()
 	ooc_allowed = !( ooc_allowed )


### PR DESCRIPTION
"Show/Hide OOC" command will only mute OOC locally in the all tab, OOC will still show up in OOC tab

Before:
Show/Hide command would hide OOC completely regardless of tab

After
Show/Hide command would hide OOC in the all tab, if they want to view OOC they can swap to the OOC tab.