### PR TITLE
Temporary wiki change to tgstation13.org

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -730,7 +730,7 @@
 			</head>
 
 			<body>
-			<iframe width='100%' height='97%' src="[config.wikiurl]/index.php?title=[page_link]&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+			<iframe width='100%' height='97%' src="[config.wikiurl]/[page_link]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
 			</body>
 
 			</html>

--- a/config/config.txt
+++ b/config/config.txt
@@ -120,7 +120,7 @@ GUEST_JOBBAN 1
 FORUMURL http://www.llagaming.net/forums/
 
 ## Wiki address
-WIKIURL http://arctys-boreas.com
+WIKIURL http://www.tgstation13.org/wiki
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 BANAPPEALS http://www.llagaming.net/forums/forums/un-ban-appeals.14/


### PR DESCRIPTION
until another wiki becomes available, the current wiki is gone and the ss13.eu wiki is full of ads.