### PR TITLE
Round Types Pooling Change

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -26,6 +26,7 @@
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/required_players = 0
 	var/required_enemies = 0
+	var/required_readies = 0
 	var/recommended_enemies = 0
 	var/pre_setup_before_jobs = 0
 	var/uplink_welcome = "Syndicate Uplink Console:"
@@ -42,10 +43,16 @@
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
 /datum/game_mode/proc/can_start()
 	var/playerC = 0
+	var/readyC = 0
 	for(var/mob/new_player/player in player_list)
 		if((player.client))
 			playerC++
+		if((player.ready))
+			readyC++
 	if(!Debug2)
+		if(required_readies)
+			if(readyC < required_readies)
+				return 0
 		if(playerC < required_players)
 			return 0
 	antag_candidates = get_players_for_role(antag_flag)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -43,7 +43,7 @@
 /datum/game_mode/proc/can_start()
 	var/playerC = 0
 	for(var/mob/new_player/player in player_list)
-		if((player.client)&&(player.ready))
+		if((player.client))
 			playerC++
 	if(!Debug2)
 		if(playerC < required_players)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -6,6 +6,7 @@
 	name = "nuclear emergency"
 	config_tag = "nuclear"
 	required_players = 18 // 18 players - 5 players to be the nuke ops = 13 players remaining
+	required_readies = 10
 	required_enemies = 5
 	recommended_enemies = 5
 	pre_setup_before_jobs = 1


### PR DESCRIPTION
Currently where it stands "fun" round types need at least 18 players ready to start generally the server has say maybe 24-30 people on and half of them do not ready up for various reasons.. which i understand. They could want to late join, ive noticed late joining is very popular, more of a choice on what job you can take, indecisive abotu what job you want.

The change i propose would be for the round types to be determined by how many players are on and in the lobby, ready or not. observers would not count. Say there are 25 players on and only 5 ready up and nuke ops is chosen, there would be 5 nuke ops and no station crew and likely a quick round, but that means there are 20 players in the lobby who will likely late join after the round starts. say there are 25 players on and only 5 in the lobby, because the other 20 observed. the count would be 5 and there would be no gamemodes except extended and traitor.

Late joining is entirely popular but it shouldnt be the factor that kills the round type chance.


I ran a test of having 18 players and 1 ready up resulting in:
The current game mode is - Secret!
Possibilities: changeling, extended, traitor and wizard

because there wasn't enough possible enemies for nuke ops. (5) . nor was there enough for revolution/cult (3). Malf did not show up because my BE_MALF preference was off. it would otherwise show up with 1 ready up and 18+ total players.

http://www.llagaming.net/forums/threads/round-types-pooling-change.4388/